### PR TITLE
Fix namespaces in phpdoc blocks

### DIFF
--- a/src/Exceptions/InvalidParameterException.php
+++ b/src/Exceptions/InvalidParameterException.php
@@ -13,10 +13,10 @@ use Exception;
  * InvalidParameterException appears when the request failed because of a bad parameter from
  * the client request.
  *
- * @package maxh\Nominatim
+ * @package \maxh\Nominatim
  * @category Exceptions
  */
 class InvalidParameterException extends Exception
 {
-    
+
 }

--- a/src/Exceptions/NominatimException.php
+++ b/src/Exceptions/NominatimException.php
@@ -34,13 +34,13 @@ class NominatimException extends Exception
      * @var ResponseInterface
      */
     private $response;
-    
+
     /**
      * Constructor
      * @param string                 $message  Message of this exception
      * @param RequestInterface       $request  The request instance
      * @param ResponseInterface|null $response The response of the request
-     * @param Exception|null        $previous Exception object
+     * @param Exception|null         $previous Exception object
      */
     public function __construct(
         $message,
@@ -59,7 +59,7 @@ class NominatimException extends Exception
 
     /**
      * Return the Request
-     * @return GuzzleHttp\Psr7\Request
+     * @return \GuzzleHttp\Psr7\Request
      */
     public function getRequest()
     {
@@ -68,7 +68,7 @@ class NominatimException extends Exception
 
     /**
      * Return the Response
-     * @return GuzzleHttp\Psr7\Response [description]
+     * @return \GuzzleHttp\Psr7\Response [description]
      */
     public function getResponse()
     {

--- a/src/Lookup.php
+++ b/src/Lookup.php
@@ -36,7 +36,7 @@ class Lookup extends Query
      *
      * @param  string $id
      *
-     * @return maxh\Nominatim\Lookup
+     * @return \maxh\Nominatim\Lookup
      */
     public function osmIds($id)
     {
@@ -50,7 +50,7 @@ class Lookup extends Query
      *
      * @param  string $polygon
      *
-     * @throws maxh\Nominatim\Exceptions\InvalidParameterException  Polygon is not supported with lookup
+     * @throws \maxh\Nominatim\Exceptions\InvalidParameterException  Polygon is not supported with lookup
      */
     public function polygon($polygon)
     {

--- a/src/Nominatim.php
+++ b/src/Nominatim.php
@@ -57,7 +57,7 @@ class Nominatim
     /**
      * Constructor
      * @param string                $application_url Contain url of the current application
-     * @param Guzzle\Client|null    $http_client     Client object from Guzzle
+     * @param \Guzzle\Client|null    $http_client     Client object from Guzzle
      */
     public function __construct(
         $application_url,
@@ -133,7 +133,7 @@ class Nominatim
      * @param  ResponseInterface $response Interface response object from Guzzle
      *
      * @return array|\SimpleXMLElement
-     * @throws maxh\Nominatim\Exceptions\NominatimException if no format for decode
+     * @throws \maxh\Nominatim\Exceptions\NominatimException if no format for decode
      */
     private function decodeResponse($format, Request $request, ResponseInterface $response)
     {
@@ -175,7 +175,7 @@ class Nominatim
 
     /**
      * Return the client using by instance
-     * @return GuzzleHttp\Client
+     * @return \GuzzleHttp\Client
      */
     public function getClient()
     {

--- a/src/Query.php
+++ b/src/Query.php
@@ -68,8 +68,8 @@ class Query implements QueryInterface
      *
      * @param  string $format The output format for the request
      *
-     * @return maxh\Nominatim\Query
-     * @throws maxh\Nominatim\Exceptions\InvalidParameterException if format is not supported
+     * @return \maxh\Nominatim\Query
+     * @throws \maxh\Nominatim\Exceptions\InvalidParameterException if format is not supported
      */
     public function format($format)
     {
@@ -94,7 +94,7 @@ class Query implements QueryInterface
      *                                  specified in the "Accept-Language" HTTP header. Either uses standard rfc2616
      *                                  accept-language string or a simple comma separated list of language codes.
      *
-     * @return maxh\Nominatim\Query
+     * @return \maxh\Nominatim\Query
      */
     public function language($language)
     {
@@ -108,7 +108,7 @@ class Query implements QueryInterface
      *
      * @param  boolean $details
      *
-     * @return maxh\Nominatim\Query
+     * @return \maxh\Nominatim\Query
      */
     public function addressDetails($details = true)
     {
@@ -124,7 +124,7 @@ class Query implements QueryInterface
      *
      * @param  string $email Address mail
      *
-     * @return maxh\Nominatim\Query
+     * @return \maxh\Nominatim\Query
      */
     public function email($email)
     {
@@ -138,8 +138,8 @@ class Query implements QueryInterface
      *
      * @param  string $polygon
      *
-     * @return maxh\Nominatim\Query
-     * @throws maxh\Nominatim\Exceptions\InvalidParameterException  if polygon format is not supported
+     * @return \maxh\Nominatim\Query
+     * @throws \maxh\Nominatim\Exceptions\InvalidParameterException  if polygon format is not supported
      */
     public function polygon($polygon)
     {
@@ -157,7 +157,7 @@ class Query implements QueryInterface
      *
      * @param  boolean $tags
      *
-     * @return maxh\Nominatim\Query
+     * @return \maxh\Nominatim\Query
      */
     public function extraTags($tags = true)
     {
@@ -172,7 +172,7 @@ class Query implements QueryInterface
      *
      * @param  boolean $details
      *
-     * @return maxh\Nominatim\Query
+     * @return \maxh\Nominatim\Query
      */
     public function nameDetails($details = true)
     {

--- a/src/Reverse.php
+++ b/src/Reverse.php
@@ -43,8 +43,8 @@ class Reverse extends Query
      *
      * @param  string $type
      *
-     * @return maxh\Nominatim\Reverse
-     * @throws maxh\Nominatim\Exceptions\InvalidParameterException  if osm type is not supported
+     * @return \maxh\Nominatim\Reverse
+     * @throws \maxh\Nominatim\Exceptions\InvalidParameterException  if osm type is not supported
      */
     public function osmType($type)
     {
@@ -62,7 +62,7 @@ class Reverse extends Query
      *
      * @param  integer $id
      *
-     * @return maxh\Nominatim\Reverse
+     * @return \maxh\Nominatim\Reverse
      */
     public function osmId($id)
     {
@@ -77,7 +77,7 @@ class Reverse extends Query
      * @param  float $lat The latitude
      * @param  float $lon The longitude
      *
-     * @return maxh\Nominatim\Reverse
+     * @return \maxh\Nominatim\Reverse
      */
     public function latlon($lat, $lon)
     {
@@ -93,7 +93,7 @@ class Reverse extends Query
      *
      * @param  integer $zoom
      *
-     * @return maxh\Nominatim\Reverse
+     * @return \maxh\Nominatim\Reverse
      */
     public function zoom($zoom)
     {

--- a/src/Search.php
+++ b/src/Search.php
@@ -39,7 +39,7 @@ class Search extends Query
      *
      * @param  string $query The query
      *
-     * @return maxh\Nominatim\Search
+     * @return \maxh\Nominatim\Search
      */
     public function query($query)
     {
@@ -55,7 +55,7 @@ class Search extends Query
      *
      * @param  string $street The street
      *
-     * @return maxh\Nominatim\Search
+     * @return \maxh\Nominatim\Search
      */
     public function street($street)
     {
@@ -71,7 +71,7 @@ class Search extends Query
      *
      * @param  string $city The city
      *
-     * @return maxh\Nominatim\Search
+     * @return \maxh\Nominatim\Search
      */
     public function city($city)
     {
@@ -87,7 +87,7 @@ class Search extends Query
      *
      * @param  string $county The county
      *
-     * @return maxh\Nominatim\Search
+     * @return \maxh\Nominatim\Search
      */
     public function county($county)
     {
@@ -103,7 +103,7 @@ class Search extends Query
      *
      * @param  string $state The state
      *
-     * @return maxh\Nominatim\Search
+     * @return \maxh\Nominatim\Search
      */
     public function state($state)
     {
@@ -119,7 +119,7 @@ class Search extends Query
      *
      * @param  string $country The country
      *
-     * @return maxh\Nominatim\Search
+     * @return \maxh\Nominatim\Search
      */
     public function country($country)
     {
@@ -135,7 +135,7 @@ class Search extends Query
      *
      * @param  integer $postalCode The postal code
      *
-     * @return maxh\Nominatim\Search
+     * @return \maxh\Nominatim\Search
      */
     public function postalCode($postalCode)
     {
@@ -152,8 +152,8 @@ class Search extends Query
      *
      * @param  string $countrycode The country code
      *
-     * @return maxh\Nominatim\Search
-     * @throws maxh\Nominatim\Exceptions\InvalidParameterException if country code is invalid
+     * @return \maxh\Nominatim\Search
+     * @throws \maxh\Nominatim\Exceptions\InvalidParameterException if country code is invalid
      */
     public function countryCode($countrycode)
     {
@@ -178,7 +178,7 @@ class Search extends Query
      * @param  string $right  Right of the area
      * @param  string $bottom Bottom of the area
      *
-     * @return maxh\Nominatim\Search
+     * @return \maxh\Nominatim\Search
      */
     public function viewBox($left, $top, $right, $bottom)
     {
@@ -190,8 +190,8 @@ class Search extends Query
     /**
      * If you do not want certain openstreetmap objects to appear in the search results.
      *
-     * @return maxh\Nominatim\Search
-     * @throws maxh\Nominatim\Exceptions\InvalidParameterException  if no place id
+     * @return \maxh\Nominatim\Search
+     * @throws \maxh\Nominatim\Exceptions\InvalidParameterException  if no place id
      */
     public function exludePlaceIds()
     {
@@ -211,7 +211,7 @@ class Search extends Query
      *
      * @param  integer $limit
      *
-     * @return maxh\Nominatim\Search
+     * @return \maxh\Nominatim\Search
      */
     public function limit($limit)
     {


### PR DESCRIPTION
## Summary

* Patch for #4

- [x] Tested
  - [x] Unit tests
  - [x] Style
- [x] Documentation (PR # )

## Goal

What do you want to achieve with this PR?

Use auto-completion in IDEs.

## Description

Class names present in `@param` and `@return` fields inside phpdoc blocks are missing prefixing slash, which makes them relative to the namespace (according to the [phpdocumentor rules](http://docs.phpdoc.org/guides/types.html#types-of-types)). In result they are invalid and break auto-completion in IDEs.
