### PR TITLE
Fix check for baseUri when using custom guzzle client

### DIFF
--- a/src/Nominatim.php
+++ b/src/Nominatim.php
@@ -100,7 +100,7 @@ class Nominatim
                 'connection_timeout' => 5,
             ]);
         } elseif ($http_client instanceof Client) {
-            $application_url_client = $http_client->getConfig('base_uri');
+            $application_url_client = (string)$http_client->getConfig('base_uri');
 
             if (empty($application_url_client)) {
                 throw new NominatimException('http_client must have a configured base_uri.');


### PR DESCRIPTION
## Summary

| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Backward C?   | yes
| Tickets       | Fix for case when using custom guzzle client. Base uri is instance of GuzzleHttp\Psr7\Uri while condition is comparing it with string.
| License       | MIT
